### PR TITLE
Add workflow proxy tools

### DIFF
--- a/src/controllers/WorkflowController.ts
+++ b/src/controllers/WorkflowController.ts
@@ -1,0 +1,92 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execPromise = promisify(exec);
+
+/**
+ * Controller handling simple workflow-based operations where a first
+ * action returns a token that must be confirmed later to retrieve the
+ * result. The token store is generic so it can hold any workflow data.
+ */
+class WorkflowController {
+  private tokenStore: Map<string, { type: string; data: any }> = new Map();
+
+  private generateToken() {
+    return Math.random().toString(36).slice(2);
+  }
+
+  async handlePerformHttpRequest(url: string, method: string = "GET", body: string = "") {
+    try {
+      const options: any = { method };
+      if (method !== "GET" && body) {
+        options.body = body;
+      }
+      const response = await fetch(url, options);
+      const text = await response.text();
+      const token = this.generateToken();
+      this.tokenStore.set(token, { type: "httpRequest", data: { status: response.status, body: text } });
+      return {
+        content: [{ type: "text", text: token }],
+        isError: false,
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          { type: "text", text: `Error performing request: ${error?.message || "Unknown error"}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  async handleConfirmHttpRequest(token: string) {
+    const entry = this.tokenStore.get(token);
+    if (!entry || entry.type !== "httpRequest") {
+      return {
+        content: [{ type: "text", text: "Invalid or expired token" }],
+        isError: true,
+      };
+    }
+    this.tokenStore.delete(token);
+    return {
+      content: [{ type: "text", text: JSON.stringify(entry.data) }],
+      isError: false,
+    };
+  }
+
+  async handlePerformPing(host: string) {
+    try {
+      const { stdout } = await execPromise(`ping -c 1 ${host}`);
+      const token = this.generateToken();
+      this.tokenStore.set(token, { type: "ping", data: stdout.trim() });
+      return {
+        content: [{ type: "text", text: token }],
+        isError: false,
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          { type: "text", text: `Error pinging host: ${error?.message || "Unknown error"}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  async handleConfirmPing(token: string) {
+    const entry = this.tokenStore.get(token);
+    if (!entry || entry.type !== "ping") {
+      return {
+        content: [{ type: "text", text: "Invalid or expired token" }],
+        isError: true,
+      };
+    }
+    this.tokenStore.delete(token);
+    return {
+      content: [{ type: "text", text: entry.data }],
+      isError: false,
+    };
+  }
+}
+
+export default WorkflowController;

--- a/src/controllers/WorkflowController.ts
+++ b/src/controllers/WorkflowController.ts
@@ -1,0 +1,52 @@
+import crypto from 'crypto';
+import NetworkController from './NetworkController.js';
+
+export const tokenStore = new Map<string, { url: string; method: string; body: string }>();
+
+class WorkflowController {
+  async handleConfirmHttpRequest(url: string, method: string = 'GET', body: string = '') {
+    try {
+      const token = crypto.randomUUID();
+      tokenStore.set(token, { url, method, body });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `About to perform ${method} request to ${url}. Call 'performHttpRequest' with provided token to continue.`,
+          },
+        ],
+        token,
+        nextTool: { name: 'performHttpRequest', arguments: { token } },
+        isError: false,
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          { type: 'text', text: `Error preparing request: ${error?.message || 'Unknown error'}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  async handlePerformHttpRequest(token: string) {
+    try {
+      const data = tokenStore.get(token);
+      if (!data) {
+        throw new Error('Invalid or expired token');
+      }
+      tokenStore.delete(token);
+      const network = new NetworkController();
+      return await network.handleHttpRequest(data.url, data.method, data.body);
+    } catch (error: any) {
+      return {
+        content: [
+          { type: 'text', text: `Error performing request: ${error?.message || 'Unknown error'}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+}
+
+export default WorkflowController;

--- a/src/controllers/WorkflowController.ts
+++ b/src/controllers/WorkflowController.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from "crypto";
+import NetworkController from "./NetworkController.js";
+
+const tokenStore = new Map<string, string>();
+
+class WorkflowController {
+  async handleConfirmPing(host: string) {
+    const token = randomUUID();
+    tokenStore.set(token, host);
+    return { content: [{ type: "text", text: token }], isError: false };
+  }
+
+  async handlePerformPing(token: string) {
+    const host = tokenStore.get(token);
+    if (!host) {
+      return {
+        content: [{ type: "text", text: "Invalid or expired token" }],
+        isError: true,
+      };
+    }
+    tokenStore.delete(token);
+    const network = new NetworkController();
+    return await network.handlePing(host);
+  }
+}
+
+export default WorkflowController;

--- a/src/definitions/workflow/confirmHttpRequest.ts
+++ b/src/definitions/workflow/confirmHttpRequest.ts
@@ -1,0 +1,15 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const CONFIRM_HTTP_REQUEST: Tool = {
+  name: "confirmHttpRequest",
+  description: "Request confirmation before performing an HTTP request. Returns a token to use with performHttpRequest.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      url: { type: "string", description: "URL to request" },
+      method: { type: "string", description: "HTTP method", default: "GET" },
+      body: { type: "string", description: "Request body", default: "" },
+    },
+    required: ["url"],
+  },
+};

--- a/src/definitions/workflow/confirmPing.ts
+++ b/src/definitions/workflow/confirmPing.ts
@@ -1,0 +1,13 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const CONFIRM_PING: Tool = {
+  name: "confirmPing",
+  description: "Confirm a host to ping and receive a token",
+  inputSchema: {
+    type: "object",
+    properties: {
+      host: { type: "string", description: "Host to ping" },
+    },
+    required: ["host"],
+  },
+};

--- a/src/definitions/workflow/main.ts
+++ b/src/definitions/workflow/main.ts
@@ -1,0 +1,5 @@
+import { CONFIRM_HTTP_REQUEST } from './confirmHttpRequest.js';
+import { PERFORM_HTTP_REQUEST } from './performHttpRequest.js';
+
+const WORKFLOW_TOOLS = [CONFIRM_HTTP_REQUEST, PERFORM_HTTP_REQUEST] as const;
+export default WORKFLOW_TOOLS;

--- a/src/definitions/workflow/main.ts
+++ b/src/definitions/workflow/main.ts
@@ -1,0 +1,5 @@
+import { CONFIRM_PING } from "./confirmPing.js";
+import { PERFORM_PING } from "./performPing.js";
+
+const WORKFLOW_TOOLS = [CONFIRM_PING, PERFORM_PING] as const;
+export default WORKFLOW_TOOLS;

--- a/src/definitions/workflow/performHttpRequest.ts
+++ b/src/definitions/workflow/performHttpRequest.ts
@@ -1,0 +1,13 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const PERFORM_HTTP_REQUEST: Tool = {
+  name: "performHttpRequest",
+  description: "Perform HTTP request using a confirmation token from confirmHttpRequest.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      token: { type: "string", description: "Confirmation token" },
+    },
+    required: ["token"],
+  },
+};

--- a/src/definitions/workflow/performPing.ts
+++ b/src/definitions/workflow/performPing.ts
@@ -1,0 +1,13 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const PERFORM_PING: Tool = {
+  name: "performPing",
+  description: "Perform a ping using a confirmation token",
+  inputSchema: {
+    type: "object",
+    properties: {
+      token: { type: "string", description: "Token from confirmPing" },
+    },
+    required: ["token"],
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     ...toolDefs.NETWORK_TOOLS,
     ...toolDefs.DATETIME_TOOLS,
     ...toolDefs.SECURITY_TOOLS,
+    ...toolDefs.WORKFLOW_TOOLS,
   ];
 
   // Just return the tools without logging
@@ -110,6 +111,7 @@ if (useSSE) {
     ...toolDefs.NETWORK_TOOLS,
     ...toolDefs.DATETIME_TOOLS,
     ...toolDefs.SECURITY_TOOLS,
+    ...toolDefs.WORKFLOW_TOOLS,
   ];
 
         return {

--- a/src/utils/toolRegistry.ts
+++ b/src/utils/toolRegistry.ts
@@ -7,6 +7,7 @@ import TextController from "../controllers/TextController.js";
 import NetworkController from "../controllers/NetworkController.js";
 import DateTimeController from "../controllers/DateTimeController.js";
 import SecurityController from "../controllers/SecurityController.js";
+import WorkflowController from "../controllers/WorkflowController.js";
 
 import FILESYSTEM_TOOLS from "../definitions/filesystem/main.js";
 import MATHS_TOOLS from "../definitions/maths/main.js";
@@ -17,6 +18,7 @@ import TEXT_TOOLS from "../definitions/text/main.js";
 import NETWORK_TOOLS from "../definitions/network/main.js";
 import DATETIME_TOOLS from "../definitions/datetime/main.js";
 import SECURITY_TOOLS from "../definitions/security/main.js";
+import WORKFLOW_TOOLS from "../definitions/workflow/main.js";
 
 type ControllerMap = {
   [key: string]: {
@@ -147,6 +149,15 @@ const controllerMap: ControllerMap = {
     controller: ShopwareController,
     handlerMethod: "handleBuild",
   },
+  // Workflow tools
+  confirmHttpRequest: {
+    controller: WorkflowController,
+    handlerMethod: "handleConfirmHttpRequest",
+  },
+  performHttpRequest: {
+    controller: WorkflowController,
+    handlerMethod: "handlePerformHttpRequest",
+  },
 };
 
 export function getToolDefinitions() {
@@ -160,6 +171,7 @@ export function getToolDefinitions() {
     NETWORK_TOOLS,
     DATETIME_TOOLS,
     SECURITY_TOOLS,
+    WORKFLOW_TOOLS,
   };
 }
 export function getToolHandler(toolName: string) {

--- a/src/utils/toolRegistry.ts
+++ b/src/utils/toolRegistry.ts
@@ -7,6 +7,7 @@ import TextController from "../controllers/TextController.js";
 import NetworkController from "../controllers/NetworkController.js";
 import DateTimeController from "../controllers/DateTimeController.js";
 import SecurityController from "../controllers/SecurityController.js";
+import WorkflowController from "../controllers/WorkflowController.js";
 
 import FILESYSTEM_TOOLS from "../definitions/filesystem/main.js";
 import MATHS_TOOLS from "../definitions/maths/main.js";
@@ -17,6 +18,7 @@ import TEXT_TOOLS from "../definitions/text/main.js";
 import NETWORK_TOOLS from "../definitions/network/main.js";
 import DATETIME_TOOLS from "../definitions/datetime/main.js";
 import SECURITY_TOOLS from "../definitions/security/main.js";
+import WORKFLOW_TOOLS from "../definitions/workflow/main.js";
 
 type ControllerMap = {
   [key: string]: {
@@ -147,6 +149,14 @@ const controllerMap: ControllerMap = {
     controller: ShopwareController,
     handlerMethod: "handleBuild",
   },
+  confirmPing: {
+    controller: WorkflowController,
+    handlerMethod: "handleConfirmPing",
+  },
+  performPing: {
+    controller: WorkflowController,
+    handlerMethod: "handlePerformPing",
+  },
 };
 
 export function getToolDefinitions() {
@@ -160,6 +170,7 @@ export function getToolDefinitions() {
     NETWORK_TOOLS,
     DATETIME_TOOLS,
     SECURITY_TOOLS,
+    WORKFLOW_TOOLS,
   };
 }
 export function getToolHandler(toolName: string) {

--- a/tests/workflow/httpProxy.test.ts
+++ b/tests/workflow/httpProxy.test.ts
@@ -1,0 +1,31 @@
+import http from 'http';
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Workflow Proxy Tools', () => {
+  it('should perform http request using token', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise<void>(resolve => server.listen(0, () => resolve()));
+    const port = (server.address() as any).port;
+
+    const controller = new WorkflowController();
+    const confirm = await controller.handleConfirmHttpRequest(`http://127.0.0.1:${port}`);
+    expect(confirm.isError).toBe(false);
+    expect(confirm).toHaveProperty('token');
+
+    const token = confirm.token as string;
+    const result = await controller.handlePerformHttpRequest(token);
+    server.close();
+    expect(result.isError).toBe(false);
+    const data = JSON.parse(result.content[0].text);
+    expect(data.status).toBe(200);
+  });
+
+  it('should fail with invalid token', async () => {
+    const controller = new WorkflowController();
+    const result = await controller.handlePerformHttpRequest('invalid');
+    expect(result.isError).toBe(true);
+  });
+});

--- a/tests/workflow/httpWorkflow.test.ts
+++ b/tests/workflow/httpWorkflow.test.ts
@@ -1,0 +1,27 @@
+import http from 'http';
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Workflow HTTP Request', () => {
+  it('should store and confirm HTTP request result', async () => {
+    const controller = new WorkflowController();
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise<void>(resolve => server.listen(0, () => resolve()));
+    const port = (server.address() as any).port;
+    const perform = await controller.handlePerformHttpRequest(`http://127.0.0.1:${port}`);
+    server.close();
+    expect(perform.isError).toBe(false);
+    const token = perform.content[0].text;
+    expect(typeof token).toBe('string');
+
+    const confirm = await controller.handleConfirmHttpRequest(token);
+    expect(confirm.isError).toBe(false);
+    const data = JSON.parse(confirm.content[0].text);
+    expect(data.status).toBe(200);
+
+    const again = await controller.handleConfirmHttpRequest(token);
+    expect(again.isError).toBe(true);
+  });
+});

--- a/tests/workflow/pingProxy.test.ts
+++ b/tests/workflow/pingProxy.test.ts
@@ -1,0 +1,18 @@
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Ping Proxy Workflow', () => {
+  it('performs ping with confirmation token', async () => {
+    const controller = new WorkflowController();
+    const confirm = await controller.handleConfirmPing('127.0.0.1');
+    expect(confirm.isError).toBe(false);
+    const token = confirm.content[0].text;
+    expect(typeof token).toBe('string');
+
+    const perform = await controller.handlePerformPing(token);
+    expect(perform.isError).toBe(false);
+    expect(perform.content[0].text).toContain('1 packets');
+
+    const reused = await controller.handlePerformPing(token);
+    expect(reused.isError).toBe(true);
+  });
+});

--- a/tests/workflow/pingWorkflow.test.ts
+++ b/tests/workflow/pingWorkflow.test.ts
@@ -1,0 +1,17 @@
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Workflow Ping', () => {
+  it('should store and confirm ping result', async () => {
+    const controller = new WorkflowController();
+    const perform = await controller.handlePerformPing('127.0.0.1');
+    expect(perform.isError).toBe(false);
+    const token = perform.content[0].text;
+
+    const confirm = await controller.handleConfirmPing(token);
+    expect(confirm.isError).toBe(false);
+    expect(confirm.content[0].text).toContain('1 packets');
+
+    const again = await controller.handleConfirmPing(token);
+    expect(again.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement WorkflowController with confirmation token logic
- define workflow tools `confirmHttpRequest` and `performHttpRequest`
- register workflow tools in the registry and server
- support new tools when listing all tools
- test proxy workflow for HTTP requests

## Testing
- `npm install` *(with puppeteer download skipped)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c333140c832fa2c29faa7e0fd9d9