### PR TITLE
Add generic workflow token store

### DIFF
--- a/src/controllers/WorkflowController.ts
+++ b/src/controllers/WorkflowController.ts
@@ -1,0 +1,92 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execPromise = promisify(exec);
+
+/**
+ * Controller handling simple workflow-based operations where a first
+ * action returns a token that must be confirmed later to retrieve the
+ * result. The token store is generic so it can hold any workflow data.
+ */
+class WorkflowController {
+  private tokenStore: Map<string, { type: string; data: any }> = new Map();
+
+  private generateToken() {
+    return Math.random().toString(36).slice(2);
+  }
+
+  async handlePerformHttpRequest(url: string, method: string = "GET", body: string = "") {
+    try {
+      const options: any = { method };
+      if (method !== "GET" && body) {
+        options.body = body;
+      }
+      const response = await fetch(url, options);
+      const text = await response.text();
+      const token = this.generateToken();
+      this.tokenStore.set(token, { type: "httpRequest", data: { status: response.status, body: text } });
+      return {
+        content: [{ type: "text", text: token }],
+        isError: false,
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          { type: "text", text: `Error performing request: ${error?.message || "Unknown error"}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  async handleConfirmHttpRequest(token: string) {
+    const entry = this.tokenStore.get(token);
+    if (!entry || entry.type !== "httpRequest") {
+      return {
+        content: [{ type: "text", text: "Invalid or expired token" }],
+        isError: true,
+      };
+    }
+    this.tokenStore.delete(token);
+    return {
+      content: [{ type: "text", text: JSON.stringify(entry.data) }],
+      isError: false,
+    };
+  }
+
+  async handlePerformPing(host: string) {
+    try {
+      const { stdout } = await execPromise(`ping -c 1 ${host}`);
+      const token = this.generateToken();
+      this.tokenStore.set(token, { type: "ping", data: stdout.trim() });
+      return {
+        content: [{ type: "text", text: token }],
+        isError: false,
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          { type: "text", text: `Error pinging host: ${error?.message || "Unknown error"}` },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  async handleConfirmPing(token: string) {
+    const entry = this.tokenStore.get(token);
+    if (!entry || entry.type !== "ping") {
+      return {
+        content: [{ type: "text", text: "Invalid or expired token" }],
+        isError: true,
+      };
+    }
+    this.tokenStore.delete(token);
+    return {
+      content: [{ type: "text", text: entry.data }],
+      isError: false,
+    };
+  }
+}
+
+export default WorkflowController;

--- a/tests/workflow/httpWorkflow.test.ts
+++ b/tests/workflow/httpWorkflow.test.ts
@@ -1,0 +1,27 @@
+import http from 'http';
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Workflow HTTP Request', () => {
+  it('should store and confirm HTTP request result', async () => {
+    const controller = new WorkflowController();
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise<void>(resolve => server.listen(0, () => resolve()));
+    const port = (server.address() as any).port;
+    const perform = await controller.handlePerformHttpRequest(`http://127.0.0.1:${port}`);
+    server.close();
+    expect(perform.isError).toBe(false);
+    const token = perform.content[0].text;
+    expect(typeof token).toBe('string');
+
+    const confirm = await controller.handleConfirmHttpRequest(token);
+    expect(confirm.isError).toBe(false);
+    const data = JSON.parse(confirm.content[0].text);
+    expect(data.status).toBe(200);
+
+    const again = await controller.handleConfirmHttpRequest(token);
+    expect(again.isError).toBe(true);
+  });
+});

--- a/tests/workflow/pingWorkflow.test.ts
+++ b/tests/workflow/pingWorkflow.test.ts
@@ -1,0 +1,17 @@
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Workflow Ping', () => {
+  it('should store and confirm ping result', async () => {
+    const controller = new WorkflowController();
+    const perform = await controller.handlePerformPing('127.0.0.1');
+    expect(perform.isError).toBe(false);
+    const token = perform.content[0].text;
+
+    const confirm = await controller.handleConfirmPing(token);
+    expect(confirm.isError).toBe(false);
+    expect(confirm.content[0].text).toContain('1 packets');
+
+    const again = await controller.handleConfirmPing(token);
+    expect(again.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `WorkflowController` with generic token store for workflow data
- support perform/confirm HTTP requests and ping actions
- test `WorkflowController` workflows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cb97f1dc832f8341e70a333e06e4