### PR TITLE
Add ping workflow tools

### DIFF
--- a/src/controllers/WorkflowController.ts
+++ b/src/controllers/WorkflowController.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from "crypto";
+import NetworkController from "./NetworkController.js";
+
+const tokenStore = new Map<string, string>();
+
+class WorkflowController {
+  async handleConfirmPing(host: string) {
+    const token = randomUUID();
+    tokenStore.set(token, host);
+    return { content: [{ type: "text", text: token }], isError: false };
+  }
+
+  async handlePerformPing(token: string) {
+    const host = tokenStore.get(token);
+    if (!host) {
+      return {
+        content: [{ type: "text", text: "Invalid or expired token" }],
+        isError: true,
+      };
+    }
+    tokenStore.delete(token);
+    const network = new NetworkController();
+    return await network.handlePing(host);
+  }
+}
+
+export default WorkflowController;

--- a/src/definitions/workflow/confirmPing.ts
+++ b/src/definitions/workflow/confirmPing.ts
@@ -1,0 +1,13 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const CONFIRM_PING: Tool = {
+  name: "confirmPing",
+  description: "Confirm a host to ping and receive a token",
+  inputSchema: {
+    type: "object",
+    properties: {
+      host: { type: "string", description: "Host to ping" },
+    },
+    required: ["host"],
+  },
+};

--- a/src/definitions/workflow/main.ts
+++ b/src/definitions/workflow/main.ts
@@ -1,0 +1,5 @@
+import { CONFIRM_PING } from "./confirmPing.js";
+import { PERFORM_PING } from "./performPing.js";
+
+const WORKFLOW_TOOLS = [CONFIRM_PING, PERFORM_PING] as const;
+export default WORKFLOW_TOOLS;

--- a/src/definitions/workflow/performPing.ts
+++ b/src/definitions/workflow/performPing.ts
@@ -1,0 +1,13 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const PERFORM_PING: Tool = {
+  name: "performPing",
+  description: "Perform a ping using a confirmation token",
+  inputSchema: {
+    type: "object",
+    properties: {
+      token: { type: "string", description: "Token from confirmPing" },
+    },
+    required: ["token"],
+  },
+};

--- a/src/utils/toolRegistry.ts
+++ b/src/utils/toolRegistry.ts
@@ -7,6 +7,7 @@ import TextController from "../controllers/TextController.js";
 import NetworkController from "../controllers/NetworkController.js";
 import DateTimeController from "../controllers/DateTimeController.js";
 import SecurityController from "../controllers/SecurityController.js";
+import WorkflowController from "../controllers/WorkflowController.js";
 
 import FILESYSTEM_TOOLS from "../definitions/filesystem/main.js";
 import MATHS_TOOLS from "../definitions/maths/main.js";
@@ -17,6 +18,7 @@ import TEXT_TOOLS from "../definitions/text/main.js";
 import NETWORK_TOOLS from "../definitions/network/main.js";
 import DATETIME_TOOLS from "../definitions/datetime/main.js";
 import SECURITY_TOOLS from "../definitions/security/main.js";
+import WORKFLOW_TOOLS from "../definitions/workflow/main.js";
 
 type ControllerMap = {
   [key: string]: {
@@ -147,6 +149,14 @@ const controllerMap: ControllerMap = {
     controller: ShopwareController,
     handlerMethod: "handleBuild",
   },
+  confirmPing: {
+    controller: WorkflowController,
+    handlerMethod: "handleConfirmPing",
+  },
+  performPing: {
+    controller: WorkflowController,
+    handlerMethod: "handlePerformPing",
+  },
 };
 
 export function getToolDefinitions() {
@@ -160,6 +170,7 @@ export function getToolDefinitions() {
     NETWORK_TOOLS,
     DATETIME_TOOLS,
     SECURITY_TOOLS,
+    WORKFLOW_TOOLS,
   };
 }
 export function getToolHandler(toolName: string) {

--- a/tests/workflow/pingProxy.test.ts
+++ b/tests/workflow/pingProxy.test.ts
@@ -1,0 +1,18 @@
+import WorkflowController from '../../src/controllers/WorkflowController.js';
+
+describe('Ping Proxy Workflow', () => {
+  it('performs ping with confirmation token', async () => {
+    const controller = new WorkflowController();
+    const confirm = await controller.handleConfirmPing('127.0.0.1');
+    expect(confirm.isError).toBe(false);
+    const token = confirm.content[0].text;
+    expect(typeof token).toBe('string');
+
+    const perform = await controller.handlePerformPing(token);
+    expect(perform.isError).toBe(false);
+    expect(perform.content[0].text).toContain('1 packets');
+
+    const reused = await controller.handlePerformPing(token);
+    expect(reused.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add WorkflowController with token-based ping flow
- define confirmPing and performPing workflow tools
- register workflow tools in registry
- test ping proxy workflow

## Testing
- `npm install` *(fails: Failed to set up chrome v133.0.6943.126)*
- `npx jest` *(fails: needs to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6849cfcb0864832fafc72afabf5591e9